### PR TITLE
Accessing Digitrust Id from iframe

### DIFF
--- a/samples/fromIframe.html
+++ b/samples/fromIframe.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Accessing Digitrust Id from Iframe</title>
+</head>
+<body>
+	This is a second iframe with domain name: 
+	<br/><br/>Trying to access Digitrust library
+
+	<pre id="user_id"></pre>
+
+	<br/>
+
+	<script type="text/javascript">
+
+		// in iframe you need to copy this function in your code
+		function callDigitrustWhileInIframe(moduleCallback) {
+
+			function findDigitrustFrame(){
+		        var f = window;
+		        var dtFrame = window;
+		        while (!dtFrame) {
+		            try {
+		                if (f.frames['__dtLocator']){
+		                	dtFrame = f;	
+		                } 
+		            } catch (e) {}
+		            if (f === window.top) break;
+		            f = f.parent;
+		        }
+		        return dtFrame;
+			}
+
+	        function readPostMessageResponse(event) {
+				if(event.data.type === "Digitrust.shareIdToIframe.response"){
+					delete event.data.type;
+					window.removeEventListener('message', readPostMessageResponse, false);
+					moduleCallback(event.data);
+				}
+	        }
+
+			var dtFrame = findDigitrustFrame();
+			var message = { type: "Digitrust.shareIdToIframe.request" };
+	        window.addEventListener('message', readPostMessageResponse, false);
+	        dtFrame.postMessage(message, '*');	       	        
+	    }
+
+	    // using callDigitrustWhileInIframe function here
+		callDigitrustWhileInIframe(function(response){
+			console.log("Got digitrust response in iframe", response);
+			document.getElementById("user_id").innerHTML = JSON.stringify(response);
+		})
+
+	</script>
+
+
+</body>
+</html>

--- a/src/config/general.json
+++ b/src/config/general.json
@@ -38,7 +38,8 @@
 		},
 		"iframe": {
 			"timeoutDuration": 10000,
-			"postMessageOrigin": "https://cdn.digitru.st"
+			"postMessageOrigin": "https://cdn.digitru.st",
+			"locatorFrameName": "__dtLocator"
 		},
 		"crypto": {
 			"serverCryptoRate": 0.4
@@ -172,7 +173,8 @@
 		},
 		"iframe": {
 			"timeoutDuration": 10000,
-			"postMessageOrigin": "http://digitrust.s3.amazonaws.com"
+			"postMessageOrigin": "http://digitrust.s3.amazonaws.com",
+			"locatorFrameName": "__dtLocator"
 		},
 		"crypto": {
 			"serverCryptoRate": 1.0
@@ -306,7 +308,8 @@
 		},
 		"iframe": {
 			"timeoutDuration": 10000,
-			"postMessageOrigin": "http://localhost"
+			"postMessageOrigin": "http://localhost",
+			"locatorFrameName": "__dtLocator"
 		},
 		"crypto": {
 			"serverCryptoRate": 1.0
@@ -440,7 +443,8 @@
 		},
 		"iframe": {
 			"timeoutDuration": 10000,
-			"postMessageOrigin": "http://localhost"
+			"postMessageOrigin": "http://localhost",
+			"locatorFrameName": "__dtLocator"
 		},
 		"crypto": {
 			"serverCryptoRate": 1.0

--- a/src/modules/DigiTrustCommunication.js
+++ b/src/modules/DigiTrustCommunication.js
@@ -140,6 +140,7 @@ DigiTrustCommunication.startConnection = function (loadSuccess) {
     DigiTrustCommunication.iframe = document.createElement('iframe');
     DigiTrustCommunication.iframe.style.display = 'none';
     DigiTrustCommunication.iframe.src = getConfig().urls.digitrustIframe;
+    DigiTrustCommunication.iframe.name = getConfig().iframe.locatorFrameName;
     DigiTrustCommunication.iframeStatus = 1;
     document.body.appendChild(DigiTrustCommunication.iframe);
 	log.debug('communication frame added');

--- a/src/modules/DigiTrustCommunication.js
+++ b/src/modules/DigiTrustCommunication.js
@@ -104,6 +104,22 @@ DigiTrustCommunication._messageHandler = function (evt) {
             case 'DigiTrust.setAppsPreferences.response':
                 helpers.MinPubSub.publish('DigiTrust.pubsub.app.setAppsPreferences.response', [evt.data.value]);
                 break;
+            case 'Digitrust.shareIdToIframe.request':
+                if(DigiTrust){
+                    DigiTrust.getUser({}, function(resp){
+                        //todo: need to handle success: false case with retry once again
+                        //console.log("Sending post message back.");
+                        resp.type = "Digitrust.shareIdToIframe.response";
+                        evt.source.postMessage(resp, evt.origin);
+                    }); 
+                }else{
+                    console.log("DigiTrust not found");
+                    //todo: need to retry once again
+                    // setTimeout(function(){
+                    //     sendDigitrustIdinPostMessage(event);
+                    // }, 500)
+                }
+                break;    
         }
     }
 };

--- a/src/modules/DigiTrustCommunication.js
+++ b/src/modules/DigiTrustCommunication.js
@@ -107,17 +107,11 @@ DigiTrustCommunication._messageHandler = function (evt) {
             case 'Digitrust.shareIdToIframe.request':
                 if(DigiTrust){
                     DigiTrust.getUser({}, function(resp){
-                        //todo: need to handle success: false case with retry once again
-                        //console.log("Sending post message back.");
                         resp.type = "Digitrust.shareIdToIframe.response";
                         evt.source.postMessage(resp, evt.origin);
                     }); 
                 }else{
-                    console.log("DigiTrust not found");
-                    //todo: need to retry once again
-                    // setTimeout(function(){
-                    //     sendDigitrustIdinPostMessage(event);
-                    // }, 500)
+                    console.log("DigiTrust not found");                    
                 }
                 break;    
         }


### PR DESCRIPTION
When DigiTrust lib is loaded on the top frame of a page, DigiTrust Id is not accessible from an iframe on the page. The changes in this PR will let code in Iframe access the DigiTrust lib.