### PR TITLE
Iframe support 2

### DIFF
--- a/samples/fromIframe.html
+++ b/samples/fromIframe.html
@@ -18,7 +18,7 @@
 
 			function findDigitrustFrame(){
 		        var f = window;
-		        var dtFrame = window;
+		        var dtFrame = null;
 		        while (!dtFrame) {
 		            try {
 		                if (f.frames['__dtLocator']){
@@ -39,10 +39,12 @@
 				}
 	        }
 
-			var dtFrame = findDigitrustFrame();
-			var message = { type: "Digitrust.shareIdToIframe.request" };
-	        window.addEventListener('message', readPostMessageResponse, false);
-	        dtFrame.postMessage(message, '*');	       	        
+	        var dtFrame = findDigitrustFrame();
+			if(dtFrame){
+				var message = { type: "Digitrust.shareIdToIframe.request" };
+				window.addEventListener('message', readPostMessageResponse, false);		    
+				dtFrame.postMessage(message, '*');
+			}
 	    }
 
 	    // using callDigitrustWhileInIframe function here

--- a/src/modules/DigiTrustCommunication.js
+++ b/src/modules/DigiTrustCommunication.js
@@ -86,7 +86,21 @@ DigiTrustCommunication.iframeStatus = 0; // 0: no iframe; 1: connecting; 2: read
 
 DigiTrustCommunication._messageHandler = function (evt) {
     if (evt.origin !== getConfig().iframe.postMessageOrigin) {
-		log.warn('message origin error. allowed: ' + getConfig().iframe.postMessageOrigin + ' \nwas from: ' + evt.origin);
+
+        switch (evt.data.type) {
+            case 'Digitrust.shareIdToIframe.request':
+                if(DigiTrust){
+                    DigiTrust.getUser({member: window.DigiTrust.initializeOptions.member}, function(resp){
+                        resp.type = "Digitrust.shareIdToIframe.response";
+                        evt.source.postMessage(resp, evt.origin);
+                    });
+                }else{
+                    console.log("DigiTrust not found");
+                }
+                break;
+            default:
+                log.warn('message origin error. allowed: ' + getConfig().iframe.postMessageOrigin + ' \nwas from: ' + evt.origin);
+        }
     } else {
         switch (evt.data.type) {
             case 'DigiTrust.iframe.ready':
@@ -103,16 +117,6 @@ DigiTrustCommunication._messageHandler = function (evt) {
                 break;
             case 'DigiTrust.setAppsPreferences.response':
                 helpers.MinPubSub.publish('DigiTrust.pubsub.app.setAppsPreferences.response', [evt.data.value]);
-                break;
-            case 'Digitrust.shareIdToIframe.request':
-                if(DigiTrust){
-                    DigiTrust.getUser({}, function(resp){
-                        resp.type = "Digitrust.shareIdToIframe.response";
-                        evt.source.postMessage(resp, evt.origin);
-                    }); 
-                }else{
-                    console.log("DigiTrust not found");                    
-                }
                 break;    
         }
     }


### PR DESCRIPTION
- In sample page fromIframe.html, setting the default value of dtFrame to null
- In DigiTrustCommunication.js, 
-- setting the value of member parameter while calling getUser function
-- moved the case of event.data.type "Digitrust.shareIdToIframe.request" to the unknown origin as this event will be triggered from unknown iframe domains.