### PR TITLE
DIS-49 Redirect lockout and throttling

### DIFF
--- a/samples/sample01.html
+++ b/samples/sample01.html
@@ -17,7 +17,11 @@
             member: 'example_member_id',
             site: 'example_site_id',
 			//logging: { level: "DEBUG", enable: true },
-			environment: {
+            environment: {
+                redir: {
+                    exp: 2,
+                    experiod: 's'
+                },
 				urls: {
                     "digitrustIframe": "http://local.digitru.st/dist/dt_debug.html",
                     "digitrustIdService": "http://local.digitru.st/misc/faked_id_service_v1.json"
@@ -26,20 +30,7 @@
 					postMessageOrigin: "http://local.digitru.st",
 					timeoutDuration: (1000 * 60)
 				}
-			},
-            adblocker: {
-                logoSrc: 'http://i.imgur.com/xfgM1wq.png',
-                logoText: 'The Seattle Times',
-                pictureSrc: 'http://i.imgur.com/IP5RRah.png',
-                blockContent: true,
-                detection: true,
-                unstyled: true,
-                customCssPath: './custom-dt.css',
-                detectedCallback: function () { console.log('Publisher executed custom code after adblock detection'); },
-                //popupFontColor: 'white', // @todo add to GitHub spec
-                //popupBackgroundColor: 'orange', // @todo add to GitHub spec
-                //userMessage: "test message"
-            }
+			}
         },
         function (digiTrustResult) {
             //console.log("Digi sample callback", digiTrustResult);
@@ -63,16 +54,6 @@
 			}
 			
         });
-        // var json = DigiTrust.getUser({member: ''});
-        // console.log(json);
-        /*var json = DigiTrust.getUser({member: '3rd_party_id'}, function (digiTrustResult) {
-            console.log('3rd party getUser result', digiTrustResult);
-            if (digiTrustResult.identity.id) {
-                DigiTrustCrypto.decrypt(digiTrustResult.identity.id, function(decryptedId) {
-                    console.log(decryptedId);
-                })
-            }
-        });*/
     </script>
 </head>
 <body>

--- a/src/config/general.json
+++ b/src/config/general.json
@@ -8,6 +8,9 @@
       "optoutInfo": "http://www.digitru.st/about-this-notice/",
       "adblockCheck": "http://stats.aws.rubiconproject.com/"
     },
+    "redir": {
+      "exp": 7
+    },
     "cookie": {
       "version": 2,
       "producer": "1CrsdUNAo6",

--- a/src/config/general.json
+++ b/src/config/general.json
@@ -8,7 +8,7 @@
       "optoutInfo": "http://www.digitru.st/about-this-notice/",
       "adblockCheck": "http://stats.aws.rubiconproject.com/"
     },
-    "redir": {
+    "redirectInterval": {
       "exp": 7
     },
     "cookie": {

--- a/src/modules/DigiTrust.js
+++ b/src/modules/DigiTrust.js
@@ -84,6 +84,54 @@ DigiTrust._setDigiTrustOptions = function (options) {
 };
 
 
+
+var newConfig = null; // instance of the cloned and merged configuration
+/**
+* @function
+* Wrapper method that merges any initialized options into the general configuration.
+*/
+DigiTrust._config.getConfig = function() {
+  var opts = window.DigiTrust.initializeOptions;
+  var env = opts && opts.environment;
+
+  if (newConfig != null) {
+    return newConfig;
+  }
+
+  var i;
+  var config = Object.assign({}, configGeneral);
+
+  // go for specific items
+  var keys = ['urls', 'iframe', 'redir']
+
+  // function to set the specific override values
+  var setVals = function (target, source, key) {
+    try {
+      var k;
+      if (source[key] == null) { return; }
+      if (target[key] == null) {
+        target[key] = {};
+      }
+      for (k in source[key]) {
+        if (source[key].hasOwnProperty(k)) {
+          target[key][k] = source[key][k];
+        }
+      }
+    }
+    catch (ex) { }
+  }
+
+  for (i = 0; i < keys.length; i++) {
+    setVals(config, env, keys[i]);
+  }
+
+  newConfig = config;
+
+  return newConfig;
+}
+
+
+
 var initInternal = function(options, initializeCallback) {
 	log.debug('init Internal');
     try {
@@ -189,6 +237,8 @@ DigiTrust.getUser = function (options, callback) {
 DigiTrust.sendReset = function (options, callback) {
     DigiTrustCommunication.sendReset();
 };
+
+
 
 module.exports = DigiTrust
 /*

--- a/src/modules/DigiTrustCommunication.js
+++ b/src/modules/DigiTrustCommunication.js
@@ -29,52 +29,8 @@ var MKEY = {
   idGet: kID + '.request'
 };
 
-var newConfig = null; // instance of the cloned and merged configuration
-/**
-* @function
-* Wrapper method that merges any initialized options into the general configuration.
-*/
-function getConfig(){
-	var opts = window.DigiTrust.initializeOptions;
-    var env = opts && opts.environment;
-
-    if (newConfig != null) {
-        return newConfig;
-    }
-	
-	var i;
-	var config = Object.assign({}, configGeneral);
-	
-	// go for specific items
-	var keys = ['urls', 'iframe']
-	
-	// function to set the specific override values
-	var setVals = function(target, source, key){
-		try{
-			var k;
-			if(source[key] == null){ return; }
-			if(target[key] == null){
-				if(source[key] == null){ return; }
-			}
-			else{
-				target[key] = {}
-			}
-			for(k in source[key]){
-				if(source[key].hasOwnProperty(k)){
-					target[key][k] = source[key][k];
-				}
-			}
-		}
-		catch(ex){}
-	}
-	
-	for(i=0;i<keys.length;i++){
-		setVals(config, env, keys[i]);
-    }
-
-    newConfig = config;
-	
-    return newConfig;
+var getConfig = function () {
+  return DigiTrust._config.getConfig();
 }
 
 /**

--- a/src/modules/helpers.js
+++ b/src/modules/helpers.js
@@ -206,10 +206,6 @@ var inIframe = function () {
     }
 };
 
-// key used in localstorage to flag redirect
-var DT_REDIR_KEY = "dtrdir";
-var REDIR_EXPIRE = 30; // days
-
 var getConfig = function () {
   return DigiTrust._config.getConfig();
 }
@@ -237,7 +233,7 @@ var flagStore = {
         return true;
       }
       var opt = getConfig(),
-        rd = opt.redir || {};
+        rd = opt.redirectInterval || {};
       s.key = rd.key || 'DigiTrust.v1.redir';
       if (rd.exp) {
         s.expire.val = rd.exp;


### PR DESCRIPTION
This implements ticket DIS-49. It prevents an unlimited redirect by setting a value in localStorage that can be read to see if the redirect has been performed already. It also cleans up some event listeners after use.